### PR TITLE
added hover & clcik interactivity on PCA scatter plot

### DIFF
--- a/landingpage/src/src/data_connector.ts
+++ b/landingpage/src/src/data_connector.ts
@@ -115,6 +115,8 @@ export function getVectorizedDataSaturation(DATA_SATURATION) {
       const data = datasets[dataset];
       vectorizedData.push({
         "name": dataset,
+        "task": task,
+        "saturation": data.saturation,
         "vector": [
           ...taskToVector[task],
           data.saturation,

--- a/landingpage/src/src/main.ts
+++ b/landingpage/src/src/main.ts
@@ -80,12 +80,18 @@ function redo_task_saturation(data_saturation) {
       columns: [
         // take first two dimensions
         ["dataset_x", ...data_saturation_new.map(d => d[0])],
-        ["dataset", ...data_saturation_new.map(d => d[2])],
+        ["dataset", ...data_saturation_new.map(d => d[1])],
       ],
-      // labels: false,
+      onclick: function (d) {
+        const data_point = data_saturation_vec[d.index];
+        fake_year_saturation(`${data_point.task} / ${data_point.name}`, data_point.saturation)
+      },
     },
     tooltip: {
-      show: false  // <--- disables hover tooltips
+      contents: function (d) {
+        const data_point = data_saturation_vec[d[0].index];
+        return `${data_point.task} / ${data_point.name}`;
+      }
     },
     axis: {
       x: {


### PR DESCRIPTION
- on HOVER, tooltip displays dataset name
- on CLICK, the main performance chart updates for selected dataset

done by passing richer data from data connector & using billboard.js's `onclick` and `tooltip.contents` event handlers

https://github.com/user-attachments/assets/30c35ac3-e137-4d73-8087-a8c76dccc64c

